### PR TITLE
Ensure the replies count makes sense.

### DIFF
--- a/src/components/ThreadListItem.vue
+++ b/src/components/ThreadListItem.vue
@@ -14,7 +14,10 @@
     </div>
 
     <div class="activity">
-      <p class="replies-count">{{ thread.repliesCount }} replies</p>
+      <p class="replies-count">
+        {{ thread.repliesCount }}
+        {{ thread.repliesCount === 1 ? "reply" : "replies" }}
+      </p>
       <AppAvatarImage
         :src="user.avatar"
         :alt="user.name"

--- a/src/pages/ThreadShow.vue
+++ b/src/pages/ThreadShow.vue
@@ -18,7 +18,10 @@
       style="float:right; margin-top: 2px"
       class="hide-mobile text-faded text-small"
     >
-      {{ thread.repliesCount }} replies by {{ thread.contributorsCount }} contributors
+      {{ thread.repliesCount }}
+      {{ thread.repliesCount === 1 ? "reply" : "replies" }}
+      by {{ thread.contributorsCount }}
+      {{ thread.contributorsCount === 1 ? "contributor" : "contributors" }}
     </span>
   </p>
 

--- a/src/store/modules/threads.js
+++ b/src/store/modules/threads.js
@@ -35,6 +35,7 @@ export default {
             return thread.posts.length - 1
           },
           get contributorsCount () {
+            if (!thread.contributors) return 0
             return thread.contributors.length
           }
         }
@@ -65,7 +66,7 @@ export default {
       )
       commit('forums/appendThreadToForum', { parentId: forumId, childId: threadRef.id }, { root: true })
       commit('users/appendThreadToUser', { parentId: userId, childId: threadRef.id }, { root: true })
-      await dispatch('posts/createPost', { text, threadId: threadRef.id }, { root: true })
+      await dispatch('posts/createPost', { text, threadId: threadRef.id, firstInThread: true }, { root: true })
       return findById(state.items, threadRef.id)
     },
     async updateThread ({ commit, state, rootState }, { title, text, id }) {


### PR DESCRIPTION
Issue - when a user creates a thread it is counted as a reply, but strictly speaking it is not a reply. Create a "firstInThread" property, set to true when creating a thread otherwise defaulting to false, and only append the user id to the thread if it is not the firstInThread.

Update the display of the count - if 1 should be reply not replies. Same for 'contributors'.